### PR TITLE
Fix EmbeddedClass preGet to avoid circular dependency

### DIFF
--- a/CoreExtension/EmbeddedClass.php
+++ b/CoreExtension/EmbeddedClass.php
@@ -199,10 +199,15 @@ final class EmbeddedClass extends Multihref
 
         if (!is_array($data)) {
             $data = $this->load($object, ['force' => true]);
-            $setter = 'set' . ucfirst($this->getName());
 
-            if (method_exists($object, $setter)) {
-                $object->$setter($data);
+            //TODO: Remove once CoreShop requires min Pimcore 5.5
+            if (method_exists($object, 'setObjectVar')) {
+                $object->setObjectVar($this->getName(), $data);
+            } else {
+                $setter = 'set' . ucfirst($this->getName());
+                if (method_exists($object, $setter)) {
+                    $object->$setter($data);
+                }
             }
         }
 


### PR DESCRIPTION
For Pimcore >= 5.5 the preGetData method was having a circular reference because the setter of the class was calling again the preGetData function.