### PR TITLE
Controller error with Pimcore X

### DIFF
--- a/Controller/Admin/DynamicDropdownController.php
+++ b/Controller/Admin/DynamicDropdownController.php
@@ -171,13 +171,18 @@ final class DynamicDropdownController extends AdminController
     private function isUsingI18n(DataObject\Concrete $object, string $method): bool
     {
         $classDefinition = $object->getClass();
-        $definitionFile = $classDefinition->getDefinitionFile();
 
-        if (!is_file($definitionFile)) {
-            return false;
+        if ($classDefinition instanceof \Pimcore\Model\DataObject\ClassDefinition) {
+            $tree = $classDefinition->getLayoutDefinitions();
+        } else {
+            $definitionFile = $classDefinition->getDefinitionFile();
+
+            if (!is_file($definitionFile)) {
+                return false;
+            }
+            $tree = include $definitionFile;
         }
 
-        $tree = include $definitionFile;
         $definition = $this->parseTree($tree, []);
 
         return $definition[$method];

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,14 @@ parameters:
 
 services:
     _defaults:
+        autowire: true
+        autoconfigure: true
         public: true
+
+    CoreShop\Bundle\PimcoreBundle\Controller\Admin\:
+        resource: '../../Controller/Admin'
+        public: true
+        tags: [ 'controller.service_arguments' ]
 
     CoreShop\Component\Pimcore\DataObject\ClassInstallerInterface: '@CoreShop\Component\Pimcore\DataObject\ClassInstaller'
     CoreShop\Component\Pimcore\DataObject\ClassInstaller: ~

--- a/Resources/config/services/dynamic_dropdown.yml
+++ b/Resources/config/services/dynamic_dropdown.yml
@@ -2,7 +2,3 @@ services:
     coreshop.pimcore_controller.dynamic_dropdown:
         alias: 'CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController'
         public: true
-
-    CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController:
-        tags:
-            - { name: controller.service_arguments }


### PR DESCRIPTION
This PR solves the issue https://github.com/coreshop/PimcoreBundle/issues/4

`Resources/config/services.yml` and `Resources/config/services/dynamic_dropdown.yml` auto-configures and registers the admin controllers.

This solves the error:
```
"CoreShop\Bundle\PimcoreBundle\Controller\Admin\DynamicDropdownController" has no container set, did you forget to define it as a service subscriber?
```

`Controller/Admin/DynamicDropdownController.php`
If the class is an instance of `Pimcore\Model\DataObject\ClassDefinition`, get the layout definition.
This solves the error:
```
Warning: Undefined array key "getName"

in vendor/coreshop/pimcore-bundle/Controller/Admin/DynamicDropdownController.php (line 183)
        $tree = include $definitionFile;
        $definition = $this->parseTree($tree, []);

        return $definition[$method];
```
when trying to get some value from the assigned class.